### PR TITLE
Remove extern

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peach-buttons"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Andrew Reid <gnomad@cryptolab.net>"]
 edition = "2018"
 description = "peach-buttons is a GPIO microservice for handling button presses, implementing a JSON-RPC server with Publish-Subscribe extension. Each button press results in a JSON-RPC request being sent over websockets to any subscribers. A button code for the pressed button is sent with the request to subscribers, allowing state-specific actions to be taken."

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # peach-buttons
 
-[![Build Status](https://travis-ci.com/peachcloud/peach-buttons.svg?branch=master)](https://travis-ci.com/peachcloud/peach-buttons) ![Generic badge](https://img.shields.io/badge/version-0.1.0-<COLOR>.svg)
+[![Build Status](https://travis-ci.com/peachcloud/peach-buttons.svg?branch=master)](https://travis-ci.com/peachcloud/peach-buttons) ![Generic badge](https://img.shields.io/badge/version-0.1.1-<COLOR>.svg)
 
 GPIO microservice module for handling button presses. `peach-buttons` implements a JSON-RPC server with [Publish-Subscribe extension](https://docs.rs/jsonrpc-pubsub/11.0.0/jsonrpc_pubsub/). Each button press results in a JSON-RPC request being sent over websockets to any subscribers. A button code for the pressed button is sent with the request to subscribers, allowing state-specific actions to be taken.
 

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -2,6 +2,7 @@ use std::{cell::Cell, process, thread, time::Duration};
 
 use crossbeam_channel::{tick, Sender};
 use gpio_cdev::{Chip, LineRequestFlags};
+use log::{debug, error, info};
 
 // initialize gpio pin and poll for state
 // send button code to "subscribe_buttons" rpc method for sink notification

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,3 @@
-#[macro_use]
-pub extern crate log;
-extern crate crossbeam_channel;
-extern crate gpio_cdev;
-
 mod error;
 mod interrupt;
 
@@ -15,6 +10,7 @@ use jsonrpc_pubsub::{PubSubHandler, Session, Subscriber, SubscriptionId};
 #[allow(unused_imports)]
 use jsonrpc_test as test;
 use jsonrpc_ws_server::{RequestContext, ServerBuilder};
+use log::{debug, error, info, warn};
 
 use crate::error::{BoxError, ButtonError::RejectSubscription};
 use crate::interrupt::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,6 @@
-extern crate peach_buttons;
-#[macro_use]
-extern crate log;
-extern crate env_logger;
-
 use std::process;
+
+use log::error;
 
 fn main() {
     env_logger::init();


### PR DESCRIPTION
Remove unnecessary `extern` statements and import required `log` macros with `use`.